### PR TITLE
Adding key renaming support in Service.upload and Handler.upload

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -6,13 +6,18 @@ var StringDecoder = require('string_decoder').StringDecoder;
  * @param {Object} provider The storage service provider
  * @param {Request} req The HTTP request
  * @param {Response} res The HTTP response
- * @param {String} container The container name
+ * @param {Object} [options] The container name
  * @callback {Function} cb Callback function
- * @header storageService.upload(provider, req, res, container, cb) 
+ * @header storageService.upload(provider, req, res, options, cb) 
  */
-exports.upload = function (provider, req, res, container, cb) {
+exports.upload = function (provider, req, res, options, cb) {
+  if (!cb && 'function' === typeof options) {
+    cb = options;
+    options = {};
+  }
+
   var form = new IncomingForm(this.options);
-  container = container || req.params.container;
+  container = options.container || req.params.container;
   var fields = {}, files = {};
   form.handlePart = function (part) {
     var self = this;
@@ -51,13 +56,18 @@ exports.upload = function (provider, req, res, container, cb) {
       type: part.mime
     };
 
+    if ('function' === typeof options.getFilename) {
+      file.name = options.getFilename(file, req, res);
+    }
+
     self.emit('fileBegin', part.name, file);
 
     var headers = {};
     if ('content-type' in part.headers) {
       headers['content-type'] = part.headers['content-type'];
     }
-    var writer = provider.upload({container: container, remote: part.filename});
+
+    var writer = provider.upload({container: container, remote: file.name});
 
     var endFunc = function () {
       self._flushing--;

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -27,6 +27,9 @@ function StorageService(options) {
   }
   this.provider = options.provider;
   this.client = factory.createClient(options);
+  if ('function' === typeof options.getFilename) {
+    this.getFilename = options.getFilename;
+  }
 }
 
 function map(obj) {
@@ -204,10 +207,18 @@ StorageService.prototype.removeFile = function (container, file, cb) {
  * Upload middleware for the HTTP request/response  <!-- Should this be documented? -->
  * @param {Request} req Request object
  * @param {Response} res Response object
+ * @param {Object} [options] Options for upload
  * @param {Function} cb Callback function
  */
-StorageService.prototype.upload = function (req, res, cb) {
-  return handler.upload(this.client, req, res, req.params.container, cb);
+StorageService.prototype.upload = function(req, res, options, cb) {
+  if (!cb && 'function' === typeof options) {
+    cb = options;
+    options = {};
+  }
+  if (this.getFilename && !options.getFilename) {
+    options.getFilename = this.getFilename;
+  }
+  return handler.upload(this.client, req, res, options, cb);
 };
 
 /**

--- a/test/images/album1/.gitignore
+++ b/test/images/album1/.gitignore
@@ -1,1 +1,2 @@
 test.jpg
+image-test.jpg


### PR DESCRIPTION
This adds a way to for the server to rename the keys of uploaded files using the service.
Addresses #20 and #36.

Usage:
Using the Service directly:
```
handler.upload(req, res, {
  container: container,
  // getFilename will be called multiple times for each "part" of the form upload
  getFilename: function(fileInfo, req, res) {
        var origFilename = fileInfo.name;
        // optimisticly get the extension
        var parts = origFilename.split('.'),
            extension = parts[parts.length-1];

        // Using a local timestamp + user id in the filename (you might want to change this)
        var newFilename = (new Date()).getTime()+'_'+req.user.id+'.'+extension;
        return uuid.v1() + '/' + newFilename;
  }
}
```
Using the datasource:
```
var ds = loopback.createDataSource({
    connector: require('loopback-component-storage'),
    provider: 'amazon',
    keyId: '...',
    key: '....',

    // getFilename will be called multiple times for each "part" of the form upload
    getFilename: function (origFilename, req, res) {
        var origFilename = fileInfo.name;
        // optimisticly get the extension
        var parts = origFilename.split('.'),
            extension = parts[parts.length-1];

        // Using a local timestamp + user id in the filename (you might want to change this)
        var newFilename = (new Date()).getTime()+'_'+req.user.id+'.'+extension;
        return uuid.v1() + '/' + newFilename;
    }
});
var container = ds.createModel('container');
app.model(container);
```

This makes it possible to follow Amazon S3 best practices for performance: http://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html