### PR TITLE
Adding a setFilename method to customize the remote filename

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -8,9 +8,14 @@ var StringDecoder = require('string_decoder').StringDecoder;
  * @param {Response} res The HTTP response
  * @param {String} container The container name
  * @callback {Function} cb Callback function
- * @header storageService.upload(provider, req, res, container, cb) 
+ * @header storageService.upload(provider, req, res, container, cb)
  */
-exports.upload = function (provider, req, res, container, cb) {
+exports.upload = function (provider, req, res, container, options, cb) {
+
+  if (typeof options === 'function') {
+      cb = options;
+  }
+
   var form = new IncomingForm(this.options);
   container = container || req.params.container;
   var fields = {}, files = {};
@@ -45,9 +50,11 @@ exports.upload = function (provider, req, res, container, cb) {
 
     this._flushing++;
 
+    var filename = (options.setFilename) ? options.setFilename(part.filename, req, res) : part.filename;
+
     var file = {
       container: container,
-      name: part.filename,
+      name: filename,
       type: part.mime
     };
 
@@ -57,7 +64,7 @@ exports.upload = function (provider, req, res, container, cb) {
     if ('content-type' in part.headers) {
       headers['content-type'] = part.headers['content-type'];
     }
-    var writer = provider.upload({container: container, remote: part.filename});
+    var writer = provider.upload({container: container, remote: filename});
 
     var endFunc = function () {
       self._flushing--;
@@ -111,7 +118,7 @@ exports.upload = function (provider, req, res, container, cb) {
  * @param {String} container The container name
  * @param {String} file The file name
  * @callback {Function} cb Callback function.
- * @header storageService.download(provider, req, res, container, file, cb) 
+ * @header storageService.download(provider, req, res, container, file, cb)
  */
 exports.download = function (provider, req, res, container, file, cb) {
   var reader = provider.download({
@@ -132,7 +139,3 @@ exports.download = function (provider, req, res, container, file, cb) {
     res.send(500, { error: err });
   });
 }
-
-
-
-

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -27,6 +27,10 @@ function StorageService(options) {
   }
   this.provider = options.provider;
   this.client = factory.createClient(options);
+
+  if (typeof options.setFilename === 'function') {
+      this.setFilename = options.setFilename;
+  }
 }
 
 function map(obj) {
@@ -207,7 +211,10 @@ StorageService.prototype.removeFile = function (container, file, cb) {
  * @param {Function} cb Callback function
  */
 StorageService.prototype.upload = function (req, res, cb) {
-  return handler.upload(this.client, req, res, req.params.container, cb);
+
+  var options = { setFilename: this.setFilename};
+
+  return handler.upload(this.client, req, res, req.params.container, options, cb);
 };
 
 /**


### PR DESCRIPTION
Sample usage : 

````js
var ds = loopback.createDataSource({
    connector: require('loopback-component-storage'),
    provider: 'amazon',
    keyId: '...',
    key: '....',

    // setFilename will be called multiple times for each "part" of the form upload
    setFilename: function (origFilename, req, res) {
        // optimisticly get the extension
        var parts = origFilename.split('.'),
            extension = parts[parts.length-1];

        // Using a local timestamp + user id in the filename (you might want to change this)
        var newFilename = (new Date()).getTime()+'_'+req.user.id+'.'+extension;
        return newFilename;
    }
});
var container = ds.createModel('container');
app.model(container);
````
