### PR TITLE
is not necessary to pass cb to pkgcloud

### DIFF
--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -136,9 +136,8 @@ StorageService.prototype.uploadStream = function (container, file, options) {
  * @param {String|Object} err Error string or object
  * @returns {Stream} Stream for downloading
  */
-StorageService.prototype.downloadStream = function (container, file, options, cb) {
-  if (!cb && typeof options === 'function') {
-    cb = options;
+StorageService.prototype.downloadStream = function (container, file, options) {
+  if (typeof options === 'function') {
     options = {};
   }
   options = options || {};
@@ -149,7 +148,7 @@ StorageService.prototype.downloadStream = function (container, file, options, cb
     options.remote = file;
   }
 
-  return this.client.download(options, cb);
+  return this.client.download(options);
 };
 
 /**

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -112,9 +112,8 @@ StorageService.prototype.getContainer = function (container, cb) {
  * @param {String|Object} err Error string or object
  * @returns {Stream} Stream for uploading
  */
-StorageService.prototype.uploadStream = function (container, file, options, cb) {
-  if (!cb && typeof options === 'function') {
-    cb = options;
+StorageService.prototype.uploadStream = function (container, file, options) {
+  if (typeof options === 'function') {
     options = {};
   }
   options = options || {};
@@ -125,7 +124,7 @@ StorageService.prototype.uploadStream = function (container, file, options, cb) 
     options.remote = file;
   }
 
-  return this.client.upload(options, cb);
+  return this.client.upload(options);
 };
 
 /**


### PR DESCRIPTION
callback in *uploadStream* method is useless because in **pkgcloud** the method accepts just *option* parameter