### PR TITLE
Adding support for ACL, Content-Type, Max File Size and allowed Content-Types

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -1,6 +1,10 @@
 var IncomingForm = require('formidable');
 var StringDecoder = require('string_decoder').StringDecoder;
 
+var defaultOptions = {
+  maxFileSize: 10 * 1024 * 1024 // 10 MB
+};
+
 /**
  * Handle multipart/form-data upload to the storage service
  * @param {Object} provider The storage service provider
@@ -14,6 +18,10 @@ exports.upload = function (provider, req, res, options, cb) {
   if (!cb && 'function' === typeof options) {
     cb = options;
     options = {};
+  }
+
+  if (!options.maxFileSize) {
+    options.maxFileSize = defaultOptions.maxFileSize;
   }
 
   var form = new IncomingForm(this.options);
@@ -56,18 +64,55 @@ exports.upload = function (provider, req, res, options, cb) {
       type: part.mime
     };
 
+    // Options for this file
+
+    // Build a filename
     if ('function' === typeof options.getFilename) {
       file.name = options.getFilename(file, req, res);
     }
 
-    self.emit('fileBegin', part.name, file);
-
-    var headers = {};
-    if ('content-type' in part.headers) {
-      headers['content-type'] = part.headers['content-type'];
+    // Get allowed mime types
+    if (options.allowedContentTypes) {
+      var allowedContentTypes;
+      if ('function' === typeof options.allowedContentTypes) {
+        allowedContentTypes = options.allowedContentTypes(file, req, res);
+      } else {
+        allowedContentTypes = options.allowedContentTypes;
+      }
+      if (Array.isArray(allowedContentTypes) && allowedContentTypes.length !== 0) {
+        if (allowedContentTypes.indexOf(file.type) === -1) {
+          self._error(new Error('contentType "' + file.type + '" is not allowed (Must be in [' + allowedContentTypes.join(', ') + '])'));
+          return;
+        }
+      }
     }
 
-    var writer = provider.upload({container: container, remote: file.name});
+    // Get max file size
+    var maxFileSize;
+    if (options.maxFileSize) {
+      if ('function' === typeof options.maxFileSize) {
+        maxFileSize = options.maxFileSize(file, req, res);
+      } else {
+        maxFileSize = options.maxFileSize;
+      }
+    }
+
+    // Get access control list
+    if (options.acl) {
+      if ('function' === typeof options.acl) {
+        file.acl = options.acl(file, req, res);
+      } else {
+        file.acl = options.acl;
+      }
+    }
+
+    self.emit('fileBegin', part.name, file);
+
+    var uploadParams = {container: container, remote: file.name, contentType: file.type};
+    if (file.acl) {
+      uploadParams.acl = file.acl;
+    }
+    var writer = provider.upload(uploadParams);
 
     var endFunc = function () {
       self._flushing--;
@@ -82,21 +127,19 @@ exports.upload = function (provider, req, res, options, cb) {
       self._maybeEnd();
     };
 
-    /*
-     part.on('data', function (buffer) {
-     self.pause();
-     writer.write(buffer, function () {
-     // pkgcloud stream doesn't make callbacks
-     });
-     self.resume();
-     });
-
-     part.on('end', function () {
-
-     writer.end(); // pkgcloud stream doesn't make callbacks
-     endFunc();
-     });
-     */
+    var fileSize = 0;
+    if (maxFileSize) {
+      part.on('data', function (buffer) {
+        fileSize += buffer.length;
+        if (fileSize > maxFileSize) {
+          // We are missing some way to tell the provider to cancel upload/multipart upload of the current file.
+          // - s3-upload-stream doesn't provide a way to do this in it's public interface
+          // - We could call provider.delete file but it would not delete multipart data 
+          self._error(new Error('maxFileSize exceeded, received ' + fileSize + ' bytes of field data (max is ' + maxFileSize + ')'));
+          return;
+        }
+      });
+    }
 
     part.pipe(writer, { end: false });
     part.on("end", function () {

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -27,9 +27,20 @@ function StorageService(options) {
   }
   this.provider = options.provider;
   this.client = factory.createClient(options);
+
   if ('function' === typeof options.getFilename) {
     this.getFilename = options.getFilename;
   }
+  if (options.acl) {
+    this.acl = options.acl;
+  }
+  if (options.allowedContentTypes) {
+    this.allowedContentTypes = options.allowedContentTypes;
+  }
+  if (options.maxFileSize) {
+    this.maxFileSize = options.maxFileSize;
+  }
+
 }
 
 function map(obj) {
@@ -217,6 +228,15 @@ StorageService.prototype.upload = function(req, res, options, cb) {
   }
   if (this.getFilename && !options.getFilename) {
     options.getFilename = this.getFilename;
+  }
+  if (this.acl && !options.acl) {
+    options.acl = this.acl;
+  }
+  if (this.allowedContentTypes && !options.allowedContentTypes) {
+    options.allowedContentTypes = this.allowedContentTypes;
+  }
+  if (this.maxFileSize && !options.maxFileSize) {
+    options.maxFileSize = this.maxFileSize;
   }
   return handler.upload(this.client, req, res, options, cb);
 };

--- a/test/images/album1/.gitignore
+++ b/test/images/album1/.gitignore
@@ -1,2 +1,2 @@
 test.jpg
-image-test.jpg
+image-*.jpg


### PR DESCRIPTION
Adds support for:
 * [x] ACL
 * [x] Content-Type
 * [x] Max File Size (defaults to 10 MB)
 * [x] Allowed Content-Types

Notes:
 * Max File Size will not cause the whole file to be downloaded, but will not cleanup after itself for now. We should discuss the best way to do this.

Examples:
```js
var dsImage = loopback.createDataSource({
  connector: require('loopback-component-storage'),
  provider: 'filesystem',
  root: path.join(__dirname, 'images'),

  getFilename: function(fileInfo) {
    return 'image-' + fileInfo.name;
  },
  acl: 'public-read',
  allowedContentTypes: ['image/png', 'image/jpeg'],
  maxFileSize: 5 * 1024 * 1024
});
```
or using the handler directly:
```js
handler.upload(req, res, {
  container: 'images',
  maxFileSize: 10 * 1024 * 1024,
  allowedContentTypes: ['image/png', 'image/jpeg'],
  acl: 'public-read',
  getFilename: function(fileInfo) {
    return 'image-' + fileInfo.name;
  }
}, function(err, result) {
});
```