### PR TITLE
Expose file size on success callback

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -135,6 +135,7 @@ exports.upload = function (provider, req, res, options, cb) {
     if (maxFileSize) {
       part.on('data', function (buffer) {
         fileSize += buffer.length;
+        file.size = fileSize;
         if (fileSize > maxFileSize) {
           // We are missing some way to tell the provider to cancel upload/multipart upload of the current file.
           // - s3-upload-stream doesn't provide a way to do this in it's public interface


### PR DESCRIPTION
Just exposed the file size property through the **file** object that later will be sent in a an array of file objects as one of the success callback attributes (line 160). This way if somebody needs to persist the file metadata in another model, it will have the whole basic pack: Container, Name, Type and now Size.