### PR TITLE
Fix for issues - #58, #23 & #67

### DIFF
--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -166,7 +166,14 @@ FileSystemProvider.prototype.upload = function (options, cb) {
   };
 
   try {
-    return fs.createWriteStream(filePath, fileOpts);
+    //simulate the success event in filesystem provider
+    //fixes: https://github.com/strongloop/loopback-component-storage/issues/58
+    // & #23 & #67
+    var stream = fs.createWriteStream(filePath, fileOpts);
+    stream.on('finish', function(){
+      stream.emit('success');
+    });
+    return stream;
   } catch (e) {
     cb && cb(e);
   }

--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -131,6 +131,10 @@ exports.upload = function (provider, req, res, options, cb) {
       self._maybeEnd();
     };
 
+    writer.on('success', function (file) {
+      endFunc();
+    });
+
     var fileSize = 0;
     if (maxFileSize) {
       part.on('data', function (buffer) {
@@ -149,7 +153,6 @@ exports.upload = function (provider, req, res, options, cb) {
     part.pipe(writer, { end: false });
     part.on("end", function () {
       writer.end();
-      endFunc();
     });
   };
 

--- a/test/storage-service.test.js
+++ b/test/storage-service.test.js
@@ -79,6 +79,13 @@ describe('Storage service', function () {
       writer.on('finish', done);
       writer.on('error', done);
     });
+    
+    it('should emit success event', function (done) {
+      var writer = storageService.uploadStream('c1', 'f1.txt');
+      fs.createReadStream(path.join(__dirname, 'files/f1.txt')).pipe(writer);
+      writer.on('success', done);
+      writer.on('error', done);
+    });
 
     it('should download a file', function (done) {
       var reader = storageService.downloadStream('c1', 'f1.txt');


### PR DESCRIPTION
Since the file system provider doesn't emit `success` event it is not consistent with pkgcloud providers. 
The code emits a `success` event from the `finish` event of file system provider.
Additionally, upload will now wait for the `success` event. This way, it will solve the problem of returning 403 from S3 for a while after upload.