### PR TITLE
Bugfix: Cannot read property 'forEach' of undefined

### DIFF
--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -123,6 +123,8 @@ FileSystemProvider.prototype.destroyContainer = function (containerName, cb) {
 
   var dir = path.join(this.root, containerName);
   fs.readdir(dir, function (err, files) {
+    files = files || [];
+
     var tasks = [];
     files.forEach(function (f) {
       tasks.push(fs.unlink.bind(fs, path.join(dir, f)));


### PR DESCRIPTION
Fix related to https://github.com/strongloop/loopback-component-storage/issues/72