### PR TITLE
Expose originalFilename when getFilename is called

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -68,6 +68,7 @@ exports.upload = function(provider, req, res, options, cb) {
 
     // Build a filename
     if ('function' === typeof options.getFilename) {
+      file.originalFilename = file.name;
       file.name = options.getFilename(file, req, res);
     }
 

--- a/test/upload-download.test.js
+++ b/test/upload-download.test.js
@@ -179,7 +179,7 @@ describe('storage service', function () {
       .expect('Content-Type', /json/)
       .expect(200, function (err, res) {
         assert.deepEqual(res.body, {"result": {"files": {"image": [
-          {"container": "album1", "name": "image-test.jpg", "type": "image/jpeg", "acl":"public-read", "size": 60475}
+          {"container": "album1", "name": "image-test.jpg", "originalFilename":"test.jpg", "type": "image/jpeg", "acl":"public-read", "size": 60475}
         ]}, "fields": {}}});
         done();
       });


### PR DESCRIPTION
Exposed **filename** property through **file** object with the original/uploaded file name, to send this later on the success callback. This allows somebody to use the original file name if is needed in the file metadata or another model.