### PR TITLE
added maxFieldsSize override to formidable limit

### DIFF
--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -40,6 +40,9 @@ function StorageService(options) {
   if (options.maxFileSize) {
     this.maxFileSize = options.maxFileSize;
   }
+  if (options.maxFieldsSize) {
+    this.maxFieldsSize = options.maxFieldsSize;
+  }
 
 }
 
@@ -235,6 +238,9 @@ StorageService.prototype.upload = function(req, res, options, cb) {
   }
   if (this.maxFileSize && !options.maxFileSize) {
     options.maxFileSize = this.maxFileSize;
+  }
+  if (this.maxFieldsSize && !options.maxFieldsSize) {
+    options.maxFieldsSize = this.maxFieldsSize;
   }
   return handler.upload(this.client, req, res, options, cb);
 };


### PR DESCRIPTION
Hi! I was attempting to upload a file larger than 2mb and I bumped into the following error:

`[Error: maxFieldsSize exceeded, received 2133296 bytes of field data]`

After some research I learned it comes from formidable's maxFieldsSize limit. The best way I could find to allow to override this option is to do it from the datasource config like this:

``` json
  "images": {
    "name": "images",
    "connector": "loopback-component-storage",
    "provider": "filesystem",
    "root": "/tmp/images",
    "maxFileSize": "52428800",
    "maxFieldsSize": "52428800"
  }
```

And add the code in this PR to support reading the override from the config. If there's an officially supported way of doing this I appreciate someone pointing me on the right direction. Otherwise, hopefully this helps.

Thanks!
Oscar
