### PR TITLE
Included mime package to detect content-type automatically based on file name

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -5,6 +5,7 @@
 
 var IncomingForm = require('formidable');
 var StringDecoder = require('string_decoder').StringDecoder;
+var mime = require('mime');
 
 var defaultOptions = {
   maxFileSize: 10 * 1024 * 1024 // 10 MB
@@ -234,7 +235,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
           var reader = provider.download(params);
 
-          res.type(file);
+          res.type(mime.lookup(file));
 
           reader.pipe(res);
           reader.on('error', function(err) {
@@ -247,7 +248,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
       var reader = provider.download(params);
 
-      res.type(file);
+      res.type(mime.lookup(file));
 
       reader.pipe(res);
       reader.on('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "test": "./node_modules/.bin/mocha --timeout 30000 test/*test.js"
   },
   "dependencies": {
-    "pkgcloud": "^1.1.0",
     "async": "^0.9.0",
-    "formidable": "^1.0.16"
+    "formidable": "^1.0.16",
+    "mime": "^1.3.4",
+    "pkgcloud": "^1.1.0"
   },
   "devDependencies": {
     "express": "^4.11.0",


### PR DESCRIPTION
The right content-type is not being returned this PR fixes the issue https://github.com/strongloop/loopback-component-storage/issues/127 by making use of the mime package to automatically detect content-type