### PR TITLE
Fixes issue #127 (Bad Content-type returned)

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -5,6 +5,7 @@
 
 var IncomingForm = require('formidable');
 var StringDecoder = require('string_decoder').StringDecoder;
+var path = require('path');
 
 var defaultOptions = {
   maxFileSize: 10 * 1024 * 1024 // 10 MB
@@ -196,7 +197,8 @@ function handleError(res, err) {
  * @header storageService.download(provider, req, res, container, file, cb)
  */
 exports.download = function(provider, req, res, container, file, cb) {
-
+  
+  var fileName = path.basename(file);
   var params = {
     container: container || req && req.params.container,
     remote: file || req && req.params.file
@@ -234,7 +236,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
           var reader = provider.download(params);
 
-          res.type(file);
+          res.type(fileName);
 
           reader.pipe(res);
           reader.on('error', function(err) {
@@ -247,7 +249,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
       var reader = provider.download(params);
 
-      res.type(file);
+      res.type(fileName);
 
       reader.pipe(res);
       reader.on('error', function(err) {


### PR DESCRIPTION
This fixes https://github.com/strongloop/loopback-component-storage/issues/127

Fixed by reading `filename` using system's `path` and passing it to `res.type` to set the proper Content-type instead of passing the `file` param.

This solves potential issues with other providers like `AWS` when the `file` param contains slashes appended to the file name. For example: **file:** `avatars/user1.png` 

This fix passes the `Download` test which also tests for the `Content-type` so no need to rewrite it. 