### PR TITLE
Add provider information to upload response

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -130,17 +130,17 @@ exports.upload = function(provider, req, res, options, cb) {
 
     var endFunc = function(providerFile) {
       self._flushing--;
-      var fileResult = file;
-      fileResult.providerResponse = providerFile;
+
+      file.providerResponse = providerFile;
 
       var values = files[part.name];
       if (values === undefined) {
-        values = [fileResult];
+        values = [file];
         files[part.name] = values;
       } else {
-        values.push(fileResult);
+        values.push(file);
       }
-      self.emit('file', part.name, fileResult);
+      self.emit('file', part.name, file);
       self._maybeEnd();
     };
 

--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -128,21 +128,24 @@ exports.upload = function(provider, req, res, options, cb) {
       self.emit('error', err);
     });
 
-    var endFunc = function() {
+    var endFunc = function(providerFile) {
       self._flushing--;
+      var fileResult = file;
+      fileResult.providerResponse = providerFile;
+
       var values = files[part.name];
       if (values === undefined) {
-        values = [file];
+        values = [fileResult];
         files[part.name] = values;
       } else {
-        values.push(file);
+        values.push(fileResult);
       }
-      self.emit('file', part.name, file);
+      self.emit('file', part.name, fileResult);
       self._maybeEnd();
     };
 
     writer.on('success', function(file) {
-      endFunc();
+      endFunc(file);
     });
 
     var fileSize = 0;
@@ -153,7 +156,7 @@ exports.upload = function(provider, req, res, options, cb) {
         if (fileSize > maxFileSize) {
           // We are missing some way to tell the provider to cancel upload/multipart upload of the current file.
           // - s3-upload-stream doesn't provide a way to do this in it's public interface
-          // - We could call provider.delete file but it would not delete multipart data 
+          // - We could call provider.delete file but it would not delete multipart data
           self._error(new Error('maxFileSize exceeded, received ' + fileSize + ' bytes of field data (max is ' + maxFileSize + ')'));
           return;
         }


### PR DESCRIPTION
This pull request aims to add provider information into the upload file response. (see #133)

In concrete terms, this PR will add a new key (_providerResponse_) in the file model returned by the upload method.

The resulting file model could look as follows (depending on the provider response) :

``` json
{
"container" : "myContainer",
"name" : "myFile",
"type" : "myMimeType",
...
"providerResponse": { 
    "filename" : "myFile",
    "hash" : "ad12d82c74...",
    ...
 }
}
```

Best regards, 
Loïc