### PR TITLE
Add provider information to upload response

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -132,8 +132,11 @@ exports.upload = function(provider, req, res, options, cb) {
       self.emit('error', err);
     });
 
-    var endFunc = function() {
+    var endFunc = function(providerFile) {
       self._flushing--;
+
+      file.providerResponse = providerFile;
+
       var values = files[part.name];
       if (values === undefined) {
         values = [file];
@@ -146,7 +149,7 @@ exports.upload = function(provider, req, res, options, cb) {
     };
 
     writer.on('success', function(file) {
-      endFunc();
+      endFunc(file);
     });
 
     var fileSize = 0;


### PR DESCRIPTION
This pull request aims to add provider information into the upload file response. (see #133)

In concrete terms, this PR will add a new key (_providerResponse_) in the file model returned by the upload method.

The resulting file model could look as follows (depending on the provider response) :

``` json
{
"container" : "myContainer",
"name" : "myFile",
"type" : "myMimeType",
...
"providerResponse": { 
    "filename" : "myFile",
    "hash" : "ad12d82c74...",
    ...
 }
}
```

Best regards, 
Loïc

Note : Same PR as #134, but with a rebased branch