### PR TITLE
Fix: Continue middleware chain after error in download.

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -181,14 +181,10 @@ exports.upload = function(provider, req, res, options, cb) {
   });
 };
 
-function handleError(res, err) {
-  if (err.code === 'ENOENT') {
-    res.type('application/json');
-    res.status(404).send({error: err});
-    return;
-  }
+function handleError(res, err, cb) {
   res.type('application/json');
-  res.status(500).send({error: err});
+
+  cb(err);
 }
 
 
@@ -222,7 +218,7 @@ exports.download = function(provider, req, res, container, file, cb) {
       provider.getFile(params.container, params.remote, function(err, stats) {
 
         if (err) {
-          handleError(res, err);
+          handleError(res, err, cb);
         } else {
           var total = stats.size;
 
@@ -246,7 +242,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
           reader.pipe(res);
           reader.on('error', function(err) {
-            handleError(res, err);
+            handleError(res, err, cb);
           });
           reader.on('end', function() {
             cb();
@@ -262,7 +258,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
       reader.pipe(res);
       reader.on('error', function(err) {
-        handleError(res, err);
+        handleError(res, err, cb);
       });
       reader.on('end', function() {
         cb();


### PR DESCRIPTION
I was not able to react to a download error, the response was directly sent from the `loopback-component-storage`.

This PR allows custom error handling on the loopback instance.
