### PR TITLE
Fix: Report 404 if file not found.

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -181,14 +181,10 @@ exports.upload = function(provider, req, res, options, cb) {
   });
 };
 
-function handleError(res, err) {
-  if (err.code === 'ENOENT') {
-    res.type('application/json');
-    res.status(404).send({error: err});
-    return;
-  }
+function handleError(res, err, cb) {
   res.type('application/json');
-  res.status(500).send({error: err});
+
+  cb(err);
 }
 
 
@@ -222,7 +218,7 @@ exports.download = function(provider, req, res, container, file, cb) {
       provider.getFile(params.container, params.remote, function(err, stats) {
 
         if (err) {
-          handleError(res, err);
+          handleError(res, err, cb);
         } else {
           var total = stats.size;
 
@@ -246,7 +242,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
           reader.pipe(res);
           reader.on('error', function(err) {
-            handleError(res, err);
+            handleError(res, err, cb);
           });
           reader.on('end', function() {
             cb();
@@ -262,7 +258,7 @@ exports.download = function(provider, req, res, container, file, cb) {
 
       reader.pipe(res);
       reader.on('error', function(err) {
-        handleError(res, err);
+        handleError(res, err, cb);
       });
       reader.on('end', function() {
         cb();

--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -184,6 +184,9 @@ exports.upload = function(provider, req, res, options, cb) {
 function handleError(res, err, cb) {
   res.type('application/json');
 
+  if (err.code === 'ENOENT')
+    err.status = 404;
+
   cb(err);
 }
 

--- a/test/upload-download.test.js
+++ b/test/upload-download.test.js
@@ -310,7 +310,7 @@ describe('storage service', function () {
     request('http://localhost:' + app.get('port'))
       .get('/containers/album1/download/test_not_exist.jpg')
       .expect('Content-Type', /json/)
-      .expect(500, function (err, res) {
+      .expect(404, function (err, res) {
         assert(res.body.error);
         done();
       });


### PR DESCRIPTION
Was incorrectly returning a `500` if it failed to find the file to download.
