### PR TITLE
Fix `use strict`

### DIFF
--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -2,10 +2,7 @@
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
-
-// Turning on strict for this file breaks;
-// disabling strict for this file
-/* eslint-disable strict */
+'use strict';
 
 // Globalization
 var g = require('strong-globalize')();
@@ -176,7 +173,7 @@ FileSystemProvider.prototype.upload = function(options, cb) {
 
   var fileOpts = {flags: options.flags || 'w+',
     encoding: options.encoding || null,
-    mode: options.mode || 0666,
+    mode: options.mode || parseInt('0666', 8),
   };
 
   try {


### PR DESCRIPTION
* Fix `use strict` for `filesystem/index.js`

Previous Error before fix and using `use strict`:
```
> loopback-component-storage@1.9.2 test /Users/jafaria/workspace/loopback-component-storage
> mocha --timeout 30000 test/*test.js

/Users/jafaria/workspace/loopback-component-storage/lib/providers/filesystem/index.js:177
    mode: options.mode || 0666),
                              ^

SyntaxError: Unexpected token )
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/jafaria/workspace/loopback-component-storage/test/fs.test.js:7:26)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at /Users/jafaria/workspace/loopback-component-storage/node_modules/mocha/lib/mocha.js:220:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/jafaria/workspace/loopback-component-storage/node_modules/mocha/lib/mocha.js:217:14)
    at Mocha.run (/Users/jafaria/workspace/loopback-component-storage/node_modules/mocha/lib/mocha.js:469:10)
    at Object.<anonymous> (/Users/jafaria/workspace/loopback-component-storage/node_modules/mocha/bin/_mocha:404:18)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:442:10)
    at startup (node.js:136:18)
    at node.js:966:3
```

/to: @loay 
/cc: @bajtos 