### PR TITLE
Fix image not found response

### DIFF
--- a/test/upload-download.test.js
+++ b/test/upload-download.test.js
@@ -91,6 +91,7 @@ describe('storage service', function() {
       .set('Content-Type', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         verifyMetadata(res.body, 'test-container');
         done();
       });
@@ -102,6 +103,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         verifyMetadata(res.body, 'test-container');
         done();
       });
@@ -113,6 +115,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         assert(Array.isArray(res.body));
         assert.equal(res.body.length, 2);
         res.body.forEach(function(c) {
@@ -128,7 +131,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        done();
+        done(err);
       });
   });
 
@@ -138,6 +141,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         assert(Array.isArray(res.body));
         assert.equal(res.body.length, 1);
         done();
@@ -150,6 +154,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         assert(Array.isArray(res.body));
         res.body.forEach(function(f) {
           verifyMetadata(f);
@@ -165,6 +170,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         assert.deepEqual(res.body, {'result': {'files': {'image': [
           {'container': 'album1', 'name': 'test.jpg', 'type': 'image/jpeg',
            'size': 60475},
@@ -180,6 +186,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) done(err);
         assert.deepEqual(res.body, {'result': {'files': {'image': [
           {'container': 'album1', 'name': 'image-test.jpg', 'originalFilename': 'test.jpg', 'type': 'image/jpeg', 'acl': 'public-read', 'size': 60475},
         ]}, 'fields': {}}});
@@ -248,6 +255,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) return done(err);
         verifyMetadata(res.body, 'test.jpg');
         done();
       });
@@ -259,6 +267,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
+        if (err) return done(err);
         verifyMetadata(res.body, 'image-test.jpg');
         done();
       });
@@ -338,7 +347,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        done();
+        done(err);
       });
   });
 
@@ -347,6 +356,7 @@ describe('storage service', function() {
       .get('/containers/album1/download/test_not_exist.jpg')
       .expect('Content-Type', /json/)
       .expect(500, function(err, res) {
+        if (err) return done(err);
         assert(res.body.error);
         done();
       });

--- a/test/upload-download.test.js
+++ b/test/upload-download.test.js
@@ -91,7 +91,7 @@ describe('storage service', function() {
       .set('Content-Type', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         verifyMetadata(res.body, 'test-container');
         done();
       });
@@ -103,7 +103,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         verifyMetadata(res.body, 'test-container');
         done();
       });
@@ -115,7 +115,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert(Array.isArray(res.body));
         assert.equal(res.body.length, 2);
         res.body.forEach(function(c) {
@@ -130,9 +130,7 @@ describe('storage service', function() {
       .del('/containers/test-container')
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
-      .expect(200, function(err, res) {
-        done(err);
-      });
+      .expect(200, done);
   });
 
   it('should list containers after delete', function(done) {
@@ -141,7 +139,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert(Array.isArray(res.body));
         assert.equal(res.body.length, 1);
         done();
@@ -154,7 +152,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert(Array.isArray(res.body));
         res.body.forEach(function(f) {
           verifyMetadata(f);
@@ -170,7 +168,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert.deepEqual(res.body, {'result': {'files': {'image': [
           {'container': 'album1', 'name': 'test.jpg', 'type': 'image/jpeg',
            'size': 60475},
@@ -186,7 +184,7 @@ describe('storage service', function() {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert.deepEqual(res.body, {'result': {'files': {'image': [
           {'container': 'album1', 'name': 'image-test.jpg', 'originalFilename': 'test.jpg', 'type': 'image/jpeg', 'acl': 'public-read', 'size': 60475},
         ]}, 'fields': {}}});
@@ -277,10 +275,7 @@ describe('storage service', function() {
     request('http://localhost:' + app.get('port'))
       .get('/containers/album1/download/test.jpg')
       .expect('Content-Type', 'image/jpeg')
-      .expect(200, function(err, res) {
-        if (err) done(err);
-        done();
-      });
+      .expect(200, done);
   });
 
   it('should run a function before a download is started by a client', function(done) {
@@ -297,7 +292,7 @@ describe('storage service', function() {
       .get('/containers/album1/download/test.jpg')
       .expect('Content-Type', 'image/jpeg')
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert(hookCalled, 'beforeRemote hook was not called');
         done();
       });
@@ -317,7 +312,7 @@ describe('storage service', function() {
       .get('/containers/album1/download/test.jpg')
       .expect('Content-Type', 'image/jpeg')
       .expect(200, function(err, res) {
-        if (err) done(err);
+        if (err) return done(err);
         assert(hookCalled, 'afterRemote hook was not called');
         done();
       });
@@ -346,16 +341,14 @@ describe('storage service', function() {
       .del('/containers/album1/files/test.jpg')
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
-      .expect(200, function(err, res) {
-        done(err);
-      });
+      .expect(200, done);
   });
 
   it('reports errors if it fails to find the file to download', function(done) {
     request('http://localhost:' + app.get('port'))
       .get('/containers/album1/download/test_not_exist.jpg')
       .expect('Content-Type', /json/)
-      .expect(500, function(err, res) {
+      .expect(404, function(err, res) {
         if (err) return done(err);
         assert(res.body.error);
         done();


### PR DESCRIPTION
right now when download function is called and image is not found, it returns a JSON in `content-type: image/jpeg` which is suboptimal, this fixes it.

- This came from trying to make CI green on LB PR's
- This PR found an issue in strong-remoting and a PR was created to fix (https://github.com/strongloop/strong-remoting/pull/390)

**6/12/16**:
- Will follow up with @bajtos to get this landed (everything seems green just need to discuss validity of this PR)

**Update 7/12/16**
- Approval from @bajtos for https://github.com/strongloop/strong-remoting/pull/390.