### PR TITLE
look for a nameConflict option and use a uuid if value is makeUnique

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -85,7 +85,7 @@ exports.upload = function(provider, req, res, options, cb) {
     if ('function' === typeof options.getFilename) {
       file.originalFilename = file.name;
       file.name = options.getFilename(file, req, res);
-    } else if(options.nameConflict === "makeUnique") {
+    } else if (options.nameConflict === 'makeUnique') {
       file.originalFilename = file.name;
       file.name = uuid.v4() + path.extname(file.name);
     }

--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -10,6 +10,7 @@ var g = require('strong-globalize')();
 var IncomingForm = require('formidable');
 var StringDecoder = require('string_decoder').StringDecoder;
 var path = require('path');
+var uuid = require('uuid');
 
 var defaultOptions = {
   maxFileSize: 10 * 1024 * 1024, // 10 MB
@@ -84,6 +85,9 @@ exports.upload = function(provider, req, res, options, cb) {
     if ('function' === typeof options.getFilename) {
       file.originalFilename = file.name;
       file.name = options.getFilename(file, req, res);
+    } else if(options.nameConflict === "makeUnique") {
+      file.originalFilename = file.name;
+      file.name = uuid.v4() + path.extname(file.name);
     }
 
     // Get allowed mime types
@@ -135,6 +139,7 @@ exports.upload = function(provider, req, res, options, cb) {
     if (file.acl) {
       uploadParams.acl = file.acl;
     }
+
     var writer = provider.upload(uploadParams);
 
     writer.on('error', function(err) {

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -46,7 +46,7 @@ function StorageService(options) {
   if (options.maxFileSize) {
     this.maxFileSize = options.maxFileSize;
   }
-  if(options.nameConflict) {
+  if (options.nameConflict) {
     this.nameConflict = options.nameConflict;
   }
 }
@@ -244,7 +244,7 @@ StorageService.prototype.upload = function(req, res, options, cb) {
   if (this.maxFileSize && !options.maxFileSize) {
     options.maxFileSize = this.maxFileSize;
   }
-  if(this.nameConflict && !options.nameConflict) {
+  if (this.nameConflict && !options.nameConflict) {
     options.nameConflict = this.nameConflict;
   }
   return handler.upload(this.client, req, res, options, cb);

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -46,6 +46,9 @@ function StorageService(options) {
   if (options.maxFileSize) {
     this.maxFileSize = options.maxFileSize;
   }
+  if(options.nameConflict) {
+    this.nameConflict = options.nameConflict;
+  }
 }
 
 function map(obj) {
@@ -240,6 +243,9 @@ StorageService.prototype.upload = function(req, res, options, cb) {
   }
   if (this.maxFileSize && !options.maxFileSize) {
     options.maxFileSize = this.maxFileSize;
+  }
+  if(this.nameConflict && !options.nameConflict) {
+    options.nameConflict = this.nameConflict;
   }
   return handler.upload(this.client, req, res, options, cb);
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "async": "^0.9.0",
     "formidable": "^1.0.16",
     "pkgcloud": "^1.1.0",
-    "strong-globalize": "^2.6.2"
+    "strong-globalize": "^2.6.2",
+    "uuid":"^3.0.1"
   },
   "devDependencies": {
     "eslint": "^2.13.1",


### PR DESCRIPTION
### Description

Currently the storage provider *always* overwrites files of the same name. To me, that's not something I'd ever do in production. I can see it being an option, but not the one I'd normally use. I added support for anew setting, in your datasources.json, called nameConflict. If you set the value to makeUnique, we *always* rename the file using a uuid. We also return the original file name. So given foo.jpg, you get UUID.jpg (extension is retained).

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
