### PR TITLE
Mark HTTP path parameters as required

### DIFF
--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -282,7 +282,7 @@ StorageService.prototype.getContainers.http =
 
 StorageService.prototype.getContainer.shared = true;
 StorageService.prototype.getContainer.accepts = [
-  {arg: 'container', type: 'string'},
+  {arg: 'container', type: 'string', required: true},
 ];
 StorageService.prototype.getContainer.returns = {
   arg: 'container',
@@ -312,7 +312,7 @@ StorageService.prototype.destroyContainer.http =
 
 StorageService.prototype.getFiles.shared = true;
 StorageService.prototype.getFiles.accepts = [
-  {arg: 'container', type: 'string'},
+  {arg: 'container', type: 'string', required: true},
 ];
 StorageService.prototype.getFiles.returns = {arg: 'files', type: 'array', root: true};
 StorageService.prototype.getFiles.http =
@@ -320,8 +320,8 @@ StorageService.prototype.getFiles.http =
 
 StorageService.prototype.getFile.shared = true;
 StorageService.prototype.getFile.accepts = [
-  {arg: 'container', type: 'string'},
-  {arg: 'file', type: 'string'},
+  {arg: 'container', type: 'string', required: true},
+  {arg: 'file', type: 'string', required: true},
 ];
 StorageService.prototype.getFile.returns = {arg: 'file', type: 'object', root: true};
 StorageService.prototype.getFile.http =
@@ -329,8 +329,8 @@ StorageService.prototype.getFile.http =
 
 StorageService.prototype.removeFile.shared = true;
 StorageService.prototype.removeFile.accepts = [
-  {arg: 'container', type: 'string'},
-  {arg: 'file', type: 'string'},
+  {arg: 'container', type: 'string', required: true},
+  {arg: 'file', type: 'string', required: true},
 ];
 StorageService.prototype.removeFile.returns = {};
 StorageService.prototype.removeFile.http =
@@ -347,8 +347,8 @@ StorageService.prototype.upload.http =
 
 StorageService.prototype.download.shared = true;
 StorageService.prototype.download.accepts = [
-  {arg: 'container', type: 'string', 'http': {source: 'path'}},
-  {arg: 'file', type: 'string', 'http': {source: 'path'}},
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
+  {arg: 'file', type: 'string', required: true, 'http': {source: 'path'}},
   {arg: 'req', type: 'object', 'http': {source: 'req'}},
   {arg: 'res', type: 'object', 'http': {source: 'res'}},
 ];


### PR DESCRIPTION
Per Swagger spec 2.0, parameters coming from the path must be marked
as required.

Before this change, the Swagger spec produced by loopback-swagger
was not valid because path parameters were optional.

Note that this commit does not fix the problem of the "uploaded"
method which does not have any swagger-supported parameters now,
and therefore the swagger spec will remain invalid (but with less
errors).