### PR TITLE
Declare container parameter for swagger spec

### DIFF
--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -225,12 +225,21 @@ StorageService.prototype.removeFile = function(container, file, cb) {
 
 /**
  * Upload middleware for the HTTP request/response  <!-- Should this be documented? -->
+ * @param {String} [container] Container name
  * @param {Request} req Request object
  * @param {Response} res Response object
  * @param {Object} [options] Options for upload
  * @param {Function} cb Callback function
  */
-StorageService.prototype.upload = function(req, res, options, cb) {
+StorageService.prototype.upload = function(container, req, res, options, cb) {
+  // Test if container is req for backward compatibility
+  if (typeof container === 'object' && container.url && container.method) {
+    // First argument is req, shift all args
+    cb = options;
+    options = res;
+    res = req;
+    req = container;
+  }
   if (!cb && 'function' === typeof options) {
     cb = options;
     options = {};
@@ -252,6 +261,9 @@ StorageService.prototype.upload = function(req, res, options, cb) {
   }
   if (this.maxFieldsSize && !options.maxFieldsSize) {
     options.maxFieldsSize = this.maxFieldsSize;
+  }
+  if (typeof container === 'string') {
+    options.container = container;
   }
   return handler.upload(this.client, req, res, options, cb);
 };
@@ -282,7 +294,7 @@ StorageService.prototype.getContainers.http =
 
 StorageService.prototype.getContainer.shared = true;
 StorageService.prototype.getContainer.accepts = [
-  {arg: 'container', type: 'string', required: true},
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
 ];
 StorageService.prototype.getContainer.returns = {
   arg: 'container',
@@ -304,7 +316,7 @@ StorageService.prototype.createContainer.http =
 
 StorageService.prototype.destroyContainer.shared = true;
 StorageService.prototype.destroyContainer.accepts = [
-  {arg: 'container', type: 'string'},
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
 ];
 StorageService.prototype.destroyContainer.returns = {};
 StorageService.prototype.destroyContainer.http =
@@ -312,7 +324,7 @@ StorageService.prototype.destroyContainer.http =
 
 StorageService.prototype.getFiles.shared = true;
 StorageService.prototype.getFiles.accepts = [
-  {arg: 'container', type: 'string', required: true},
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
 ];
 StorageService.prototype.getFiles.returns = {arg: 'files', type: 'array', root: true};
 StorageService.prototype.getFiles.http =
@@ -320,8 +332,8 @@ StorageService.prototype.getFiles.http =
 
 StorageService.prototype.getFile.shared = true;
 StorageService.prototype.getFile.accepts = [
-  {arg: 'container', type: 'string', required: true},
-  {arg: 'file', type: 'string', required: true},
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
+  {arg: 'file', type: 'string', required: true, 'http': {source: 'path'}},
 ];
 StorageService.prototype.getFile.returns = {arg: 'file', type: 'object', root: true};
 StorageService.prototype.getFile.http =
@@ -329,8 +341,8 @@ StorageService.prototype.getFile.http =
 
 StorageService.prototype.removeFile.shared = true;
 StorageService.prototype.removeFile.accepts = [
-  {arg: 'container', type: 'string', required: true},
-  {arg: 'file', type: 'string', required: true},
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
+  {arg: 'file', type: 'string', required: true, 'http': {source: 'path'}},
 ];
 StorageService.prototype.removeFile.returns = {};
 StorageService.prototype.removeFile.http =
@@ -338,6 +350,7 @@ StorageService.prototype.removeFile.http =
 
 StorageService.prototype.upload.shared = true;
 StorageService.prototype.upload.accepts = [
+  {arg: 'container', type: 'string', required: true, 'http': {source: 'path'}},
   {arg: 'req', type: 'object', 'http': {source: 'req'}},
   {arg: 'res', type: 'object', 'http': {source: 'res'}},
 ];

--- a/test/images/album1/.gitignore
+++ b/test/images/album1/.gitignore
@@ -1,3 +1,4 @@
 test.jpg
 image-*.jpg
 customimagefield_test.jpg
+customimagefield1_test.jpg

--- a/test/upload-download.test.js
+++ b/test/upload-download.test.js
@@ -32,6 +32,23 @@ app.post('/custom/upload', function(req, res, next) {
   });
 });
 
+// custom route with renamer
+app.post('/custom/uploadWithContainer', function(req, res, next) {
+  var options = {
+    getFilename: function(file, req, res) {
+      return file.field + '_' + file.name;
+    },
+  };
+  ds.connector.upload('album1', req, res, options, function(err, result) {
+    if (!err) {
+      res.setHeader('Content-Type', 'application/json');
+      res.status(200).send({result: result});
+    } else {
+      res.status(500).send(err);
+    }
+  });
+});
+
 // expose a rest api
 app.use(loopback.rest());
 
@@ -416,6 +433,22 @@ describe('storage service', function() {
           {'container': 'album1', 'name': 'customimagefield_test.jpg',
             'originalFilename': 'test.jpg', 'type': 'image/jpeg',
             'field': 'customimagefield', 'size': 60475},
+        ]}, 'fields': {}}});
+        done();
+      });
+  });
+
+  it('should upload a file with container param', function(done) {
+    request('http://localhost:' + app.get('port'))
+      .post('/custom/uploadWithContainer')
+      .attach('customimagefield1', path.join(__dirname, './fixtures/test.jpg'))
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200, function(err, res) {
+        assert.deepEqual(res.body, {'result': {'files': {'customimagefield1': [
+          {'container': 'album1', 'name': 'customimagefield1_test.jpg',
+            'originalFilename': 'test.jpg', 'type': 'image/jpeg',
+            'field': 'customimagefield1', 'size': 60475},
         ]}, 'fields': {}}});
         done();
       });


### PR DESCRIPTION
Without this change, generated Swagger spec for the upload operation
does not have `container` parameter even it's a variable on the path.
As a result, the sepc fails validations.

An optional `container` is added to the remote method. Conditional
check is added to ensure backward compatibility.

### Description
This is a follow-up fix on https://github.com/strongloop/loopback-component-storage/pull/219

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
