### PR TITLE
feat(aws-options): add AWS S3 options for server side encryption

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -141,6 +141,30 @@ exports.upload = function(provider, req, res, options, cb) {
       uploadParams.acl = file.acl;
     }
 
+    // add AWS specific options
+    // See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+    if (options.StorageClass) {
+      uploadParams.StorageClass = options.StorageClass;
+    }
+    if (options.CacheControl) {
+      uploadParams.CacheControl = options.CacheControl;
+    }
+    if (options.ServerSideEncryption) {
+      uploadParams.ServerSideEncryption = options.ServerSideEncryption;
+    }
+    if (options.SSEKMSKeyId) {
+      uploadParams.SSEKMSKeyId = options.SSEKMSKeyId;
+    }
+    if (options.SSECustomerAlgorithm) {
+      uploadParams.SSECustomerAlgorithm = options.SSECustomerAlgorithm;
+    }
+    if (options.SSECustomerKey) {
+      uploadParams.SSECustomerKey = options.SSECustomerKey;
+    }
+    if (options.SSECustomerKeyMD5) {
+      uploadParams.SSECustomerKeyMD5 = options.SSECustomerKeyMD5;
+    }
+
     var writer = provider.upload(uploadParams);
 
     writer.on('error', function(err) {


### PR DESCRIPTION
Now, the AWS S3 options for server side encryptions are passed to the upload handler. Thus, the client can specify the AWS options and use AWS Server Side Encryption.

### Description

Pass upload properties for server side encryption of AWS S3 (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) from options to upload parameters.

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)