### PR TITLE
Update validateName() to support file name with slash

### DIFF
--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -43,6 +43,7 @@ function FileSystemProvider(options) {
 var namePattern = new RegExp('[^' + path.sep + '/]+');
 // To detect any file/directory containing dotdot paths
 var containsDotDotPaths = /(^|[\\\/])\.\.([\\\/]|$)/;
+var multiNameSpacePattern = new RegExp('^(.*/)([^/]*)$');
 
 function validateName(name, cb) {
   if (!name || containsDotDotPaths.test(name)) {
@@ -56,6 +57,11 @@ function validateName(name, cb) {
   if (match && match.index === 0 && match[0].length === name.length) {
     return true;
   } else {
+    // Allow multiple file path as the filename,such as '/namespace1/namespace2/filename' 
+    var matchM = multiNameSpacePattern.exec(name);
+    if (matchM && matchM.index === 0 && matchM[0].length === name.length) {
+      return true;
+    }
     cb && process.nextTick(cb.bind(null,
       new Error(g.f('{{FileSystemProvider}}: Invalid name: %s', name))));
     if (!cb) {
@@ -200,6 +206,17 @@ FileSystemProvider.prototype.upload = function(options, cb) {
     mode: options.mode || parseInt('0666', 8),
   };
 
+  // If folders do not exist, try to create folder.
+  let dataPath = '';
+  const dirs = filePath.split('/');
+  for (let i = 0; i < dirs.length - 1; i += 1) {
+    dataPath += `${dirs[i]}/`;
+    // logger.silly(`Current filesToRoot is  ${dataPath}`);
+    if (!fs.existsSync(dataPath)) {
+      fs.mkdirSync(dataPath);
+    }
+  }
+  
   try {
     // simulate the success event in filesystem provider
     // fixes: https://github.com/strongloop/loopback-component-storage/issues/58


### PR DESCRIPTION
### Description


#### Related issues
#231 

### Checklist
- [ ] Allow upload files with slash in the name, such as '/namespace1/namespace2/filename'
- [ ] Create folder if it does not exist in file path '/namespace1/namespace2/filename'

