### PR TITLE
Bugfix: Cannot read property 'forEach' of undefined.

### DIFF
--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -99,6 +99,7 @@ FileSystemProvider.prototype.getContainers = function(cb) {
   fs.readdir(self.root, function(err, files) {
     var containers = [];
     var tasks = [];
+    var files = files || [];
     files.forEach(function(f) {
       tasks.push(fs.stat.bind(fs, path.join(self.root, f)));
     });


### PR DESCRIPTION
### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
