### PR TITLE
Updated "getFile" to send 404 for ENOENT errors

### DIFF
--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -210,6 +210,10 @@ StorageService.prototype.getFiles = function(container, options, cb) {
  */
 StorageService.prototype.getFile = function(container, file, cb) {
   return this.client.getFile(container, file, function(err, f) {
+    if (err && err.code === 'ENOENT') {
+      err.statusCode = err.status = 404;
+      return cb(err);
+    }
     return cb(err, map(f));
   });
 };

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -196,6 +196,15 @@ describe('FileSystem based storage provider', function() {
       });
     });
 
+    it('should not get a file from a container', function(done) {
+      client.getFile('c1', 'f2.txt', function(err, f) {
+        assert(err);
+        assert.equal('ENOENT', err.code);
+        assert(!f);
+        done();
+      });
+    });
+
     it('should destroy a container c1', function(done) {
       client.destroyContainer('c1', function(err, container) {
         // console.error(err);

--- a/test/storage-service.test.js
+++ b/test/storage-service.test.js
@@ -133,6 +133,16 @@ describe('Storage service', function() {
       });
     });
 
+    it('should not get a file from a container', function(done) {
+      storageService.getFile('c1', 'f1.txt', function(err, f) {
+        assert(err);
+        assert.equal('ENOENT', err.code);
+        assert.equal(404, err.status);
+        assert(!f);
+        done();
+      });
+    });
+
     it('should destroy a container c1', function(done) {
       storageService.destroyContainer('c1', function(err, container) {
         // console.error(err);
@@ -142,4 +152,3 @@ describe('Storage service', function() {
     });
   });
 });
-


### PR DESCRIPTION
### Description

Currently, the getFile method sends a 500 error response when the requested file cannot be found, but the status code probably should be 404.

This change sets the status property of the error object to 404 when the value of the code property is equal to ENOENT.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #4

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
