### PR TITLE
Rename uploading files

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -82,6 +82,11 @@ exports.upload = function(provider, req, res, options, cb) {
       field: part.name,
     };
 
+    // Rename file before saving
+    if (options.hasOwnProperty('targetFileName')) {
+      file.name = options.targetFileName;
+    }
+
     // Options for this file
 
     // Build a filename

--- a/test/images/album1/.gitignore
+++ b/test/images/album1/.gitignore
@@ -1,4 +1,2 @@
-test.jpg
-image-*.jpg
-customimagefield_test.jpg
-customimagefield1_test.jpg
+*
+!.gitignore


### PR DESCRIPTION
### Description
This PR adds the feature to rename files before they reach the destination - filesystem or cloud. 

I have made additional changes to the test cases and edited the `.gitignore` file under `/test/images/album1`. Reason: each unit test should be self-contained.

NOTE: This feature depends on an update in `strong-remoting`. CI will fail till `strong-remoting` is updated (it is not updated yet).

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-component-storage/issues/240

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
