### PR TITLE
Pass through AWS/S3 specific options

### DIFF
--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -147,28 +147,21 @@ exports.upload = function(provider, req, res, options, cb) {
       uploadParams.acl = file.acl;
     }
 
-    // add AWS specific options
+    // AWS specific options
     // See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
-    if (options.StorageClass) {
-      uploadParams.StorageClass = options.StorageClass;
-    }
-    if (options.CacheControl) {
-      uploadParams.CacheControl = options.CacheControl;
-    }
-    if (options.ServerSideEncryption) {
-      uploadParams.ServerSideEncryption = options.ServerSideEncryption;
-    }
-    if (options.SSEKMSKeyId) {
-      uploadParams.SSEKMSKeyId = options.SSEKMSKeyId;
-    }
-    if (options.SSECustomerAlgorithm) {
-      uploadParams.SSECustomerAlgorithm = options.SSECustomerAlgorithm;
-    }
-    if (options.SSECustomerKey) {
-      uploadParams.SSECustomerKey = options.SSECustomerKey;
-    }
-    if (options.SSECustomerKeyMD5) {
-      uploadParams.SSECustomerKeyMD5 = options.SSECustomerKeyMD5;
+    const awsOptionNames = [
+      'StorageClass',
+      'CacheControl',
+      'ServerSideEncryption',
+      'SSEKMSKeyId',
+      'SSECustomerAlgorithm',
+      'SSECustomerKey',
+      'SSECustomerKeyMD5',
+    ];
+    for (const awsOption of awsOptionNames) {
+      if (typeof options[awsOption] !== 'undefined') {
+        uploadParams[awsOption] = options[awsOption];
+      }
     }
 
     var writer = provider.upload(uploadParams);

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -54,6 +54,22 @@ function StorageService(options) {
   if (options.maxFieldsSize) {
     this.maxFieldsSize = options.maxFieldsSize;
   }
+  // AWS specific options
+  // See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+  const awsOptionNames = [
+    'StorageClass',
+    'CacheControl',
+    'ServerSideEncryption',
+    'SSEKMSKeyId',
+    'SSECustomerAlgorithm',
+    'SSECustomerKey',
+    'SSECustomerKeyMD5',
+  ];
+  for (const awsOption of awsOptionNames) {
+    if (typeof options[awsOption] !== 'undefined') {
+      this[awsOption] = options[awsOption];
+    }
+  }
 }
 
 function map(obj) {
@@ -304,9 +320,28 @@ StorageService.prototype.upload = function(container, req, res, options, cb) {
   if (this.maxFieldsSize && !options.maxFieldsSize) {
     options.maxFieldsSize = this.maxFieldsSize;
   }
+
+  // AWS specific options
+  // See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+  const awsOptionNames = [
+    'StorageClass',
+    'CacheControl',
+    'ServerSideEncryption',
+    'SSEKMSKeyId',
+    'SSECustomerAlgorithm',
+    'SSECustomerKey',
+    'SSECustomerKeyMD5',
+  ];
+  for (const awsOption of awsOptionNames) {
+    if (this[awsOption] && !options[awsOption]) {
+      options[awsOption] = this[awsOption];
+    }
+  }
+
   if (typeof container === 'string') {
     options.container = container;
   }
+
   debug('Upload configured with options %o', options);
 
   handler.upload(this.client, req, res, options, cb);


### PR DESCRIPTION
### Description

This allows S3 options to be pulled through from datasources.json. Currently they are ignored.

For example, if `ServerSideEncryption` is set to `AES256` then the file created in the bucket does not have encryption set.

These include:
* StorageClass
* CacheControl
* ServerSideEncryption
* SSEKMSKeyId
* SSECustomerAlgorithm
* SSECustomerKey
* SSECustomerKeyMD5

Note: automated tests would need to connect to S3 and check the file has been uploaded with the correct options set.

#### Related issues

- connect to https://github.com/strongloop/loopback-component-storage/commit/e1109e39dd1260d1c4030bc972d5cd0039a7bd57

### Checklist

- [?] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
