### PR TITLE
chore: update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "async": "^2.6.1",
     "debug": "^3.1.0",
     "formidable": "^1.2.1",
-    "pkgcloud": "^2.1.1",
+    "pkgcloud": "github:ScriptSmith/pkgcloud#63549f5",
     "strong-globalize": "^4.1.1",
     "uuid": "^3.2.1"
   },


### PR DESCRIPTION
Update the dependencies:

Solution is from https://github.com/ppproxy/loopback-component-storage/commit/1ab25b68910b37bf0dd2db697ec363a804483e8a

The vulnerability package path is:
loopback-component-storage@3.6.3 › pkgcloud@2.2.0 › liboneandone@1.2.0 › mocha@2.5.3 › growl@1.9.2

While `liboneandone` is not maintained anymore, more discussion see https://github.com/pkgcloud/pkgcloud/issues/644, https://github.com/pkgcloud/pkgcloud/issues/675, https://github.com/pkgcloud/pkgcloud/pull/671
