### PR TITLE
chore: update copyright year

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/lib/providers/filesystem/container.js
+++ b/lib/providers/filesystem/container.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/lib/providers/filesystem/file.js
+++ b/lib/providers/filesystem/file.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/lib/providers/filesystem/index.js
+++ b/lib/providers/filesystem/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/lib/storage-connector.js
+++ b/lib/storage-connector.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/test/storage-service.test.js
+++ b/test/storage-service.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/test/upload-download.test.js
+++ b/test/upload-download.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-component-storage
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0


### PR DESCRIPTION
Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-component-storage) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
